### PR TITLE
Add param and concat element names

### DIFF
--- a/seq2xml.py
+++ b/seq2xml.py
@@ -52,6 +52,7 @@ def seq2xml(seq, seq_name, out_folder):
 
     # Parameters is the root of the xml
     root = ET.Element("Parameters")
+    root.set("Name", "P")
     # Add gradient limits (seem to be the only parameters shared by both formats)
     # TODO check units
     root.set("GradMaxAmpl", str(seq.system.max_grad*g_const))
@@ -60,6 +61,7 @@ def seq2xml(seq, seq_name, out_folder):
     # ConcatSequence is the element for the sequence itself;
     # Allows addition of multiple AtomicSequence
     C0 = ET.SubElement(root, "ConcatSequence")
+    C0.set("Name", "CON1")
 
     # Use helper functions to save all RF and only arbitrary gradient info
     rf_shapes_path_dict = save_rf_library_info(seq, out_folder)


### PR DESCRIPTION
The JEMRIS_seq GUI throws up errors if the Parameters and ConcatSequence elements don't have the "Name" field set. This fixes that.